### PR TITLE
Ai prompt file

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -620,7 +620,7 @@ SE_DIR = "{}/{}".format(repo.workdir, SE_DIR)
 
 pathlib.Path(SE_DIR).mkdir(parents=True, exist_ok=True)
 
-ai_file = open("{}/git-se.txt".format(SE_DIR), "w")
+ai_file = open("{}/ai-prompt.txt".format(SE_DIR), "w")
 recreator_file = open("{}/git-se.recreator.sh".format(SE_DIR), "w")
 
 recreator_branch = "git-se/{}/recreator".format(first_commit)

--- a/git-se.py
+++ b/git-se.py
@@ -532,7 +532,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
 
             global ai_chapter
             ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line))
-            ai_file.write("```\n")
+            ai_file.write("```diff\n")
             ai_chapter += 1
             for c in cfg:
                 c.export_patch(ai_file, "")


### PR DESCRIPTION
## 1. Add diff Markdown styler before any patch

The changeset adds a Markdown styler to the diff output in a
Python script. Specifically, it modifies the code to write
"```diff" before the patch content is written to a file.
This change ensures that the patch content is styled as a
diff when viewed in Markdown format.

```diff
diff --git a/git-se.py b/git-se.py
index a41182f..fc6a12c 100755
--- a/git-se.py
+++ b/git-se.py
@@ -532,7 +532,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
 
             global ai_chapter
             ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line))
-            ai_file.write("```\n")
+            ai_file.write("```diff\n")
             ai_chapter += 1
             for c in cfg:
                 c.export_patch(ai_file, "")

```

## 2. Rename output AI prompt file

The changeset modifies a Python script named `git-se.py`.
Specifically, it updates the file path used to create a new
file. The patch changes the output file name from `git-
se.txt` to `ai-prompt.txt`. This change aims to provide a
more descriptive and accurate name for the output file
generated by the script.

```diff
diff --git a/git-se.py b/git-se.py
index 6215c01..fc6a12c 100755
--- a/git-se.py
+++ b/git-se.py
@@ -620,7 +620,7 @@ SE_DIR = "{}/{}".format(repo.workdir, SE_DIR)
 
 pathlib.Path(SE_DIR).mkdir(parents=True, exist_ok=True)
 
-ai_file = open("{}/git-se.txt".format(SE_DIR), "w")
+ai_file = open("{}/ai-prompt.txt".format(SE_DIR), "w")
 recreator_file = open("{}/git-se.recreator.sh".format(SE_DIR), "w")
 
 recreator_branch = "git-se/{}/recreator".format(first_commit)

```
