### PR TITLE
Ai prompt file

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -679,5 +679,5 @@ ai_file.close()
 
 repo.checkout(origin_ref)
 
-subprocess.Popen(["/usr/bin/env", "bash", "-c", "cat {}/git-se.txt | copyq copy -".format(SE_DIR)])
+subprocess.Popen(["/usr/bin/env", "bash", "-c", "cat {}/{} | copyq copy -".format(SE_DIR, AI_PROMPT_FILENAME)])
 

--- a/git-se.py
+++ b/git-se.py
@@ -25,6 +25,7 @@ ai_file = None
 recreator_file = None
 oai = None
 OAI_MODEL = "gpt-3.5-turbo"
+AI_PROMPT_FILENAME = "ai-prompt.txt"
 
 class LineType(Enum):
     HEADER = 1

--- a/git-se.py
+++ b/git-se.py
@@ -525,6 +525,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     logger.debug("gpt: {}".format(response.choices[0].message.content))
                     wrapped = textwrap.wrap(response.choices[0].message.content, 60, break_long_words=False)
                     pd_com_line += "\n\n"
+                    pd_com_line_unwrapped += "\n\n{}\n".format(response.choices[0].message.content)
                     for lin in wrapped:
                         pd_com_line += lin + "\n"
 
@@ -533,8 +534,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             recreator_file.write("EOF\n")
 
             global ai_chapter
-            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line))
-            ai_file.write("```\n")
+            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line_unwrapped))
+            ai_file.write("```diff\n")
             ai_chapter += 1
             for c in cfg:
                 c.export_patch(ai_file, "")

--- a/git-se.py
+++ b/git-se.py
@@ -621,7 +621,7 @@ SE_DIR = "{}/{}".format(repo.workdir, SE_DIR)
 
 pathlib.Path(SE_DIR).mkdir(parents=True, exist_ok=True)
 
-ai_file = open("{}/git-se.txt".format(SE_DIR), "w")
+ai_file = open("{}/{}".format(SE_DIR, AI_PROMPT_FILENAME), "w")
 recreator_file = open("{}/git-se.recreator.sh".format(SE_DIR), "w")
 
 recreator_branch = "git-se/{}/recreator".format(first_commit)

--- a/git-se.py
+++ b/git-se.py
@@ -501,6 +501,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             logger.debug("comment: {}".format(com_line))
             pd_com_line = com_line
             pd_com_line = pd_com_line.strip(" \t\n")
+            pd_com_line_unwrapped = pd_com_line
 
             # ask AI to generate some description
             if oai:


### PR DESCRIPTION
## 1. Introduce a new variable for AI prompt file name

The changeset introduces a new variable named `AI_PROMPT_FILENAME` with the value `"ai-prompt.txt"` in the file `git-se.py`. This variable is added alongside existing variables like `ai_file`, `recreator_file`, `oai`, and `OAI_MODEL`. The new variable is intended to store the file name for the AI prompt.

```diff
diff --git a/git-se.py b/git-se.py
index a41182f..fecffbb 100755
--- a/git-se.py
+++ b/git-se.py
@@ -25,6 +25,7 @@ ai_file = None
 recreator_file = None
 oai = None
 OAI_MODEL = "gpt-3.5-turbo"
+AI_PROMPT_FILENAME = "ai-prompt.txt"
 
 class LineType(Enum):
     HEADER = 1

```

## 2. AI Prompt file name is using AI_PROMPT_FILENAME

The changeset modifies the file path used to create the AI Prompt file. Instead of using a hardcoded file name "git-se.txt", it now uses a variable "AI_PROMPT_FILENAME" to dynamically generate the file name. This change allows for more flexibility and easier customization of the AI Prompt file name.

```diff
diff --git a/git-se.py b/git-se.py
index 7d2a103..fecffbb 100755
--- a/git-se.py
+++ b/git-se.py
@@ -621,7 +621,7 @@ SE_DIR = "{}/{}".format(repo.workdir, SE_DIR)
 
 pathlib.Path(SE_DIR).mkdir(parents=True, exist_ok=True)
 
-ai_file = open("{}/git-se.txt".format(SE_DIR), "w")
+ai_file = open("{}/{}".format(SE_DIR, AI_PROMPT_FILENAME), "w")
 recreator_file = open("{}/git-se.recreator.sh".format(SE_DIR), "w")
 
 recreator_branch = "git-se/{}/recreator".format(first_commit)

```

## 3. When copying to clipboard use the right file name

The changeset modifies the script `git-se.py` to improve the copying functionality to the clipboard. Previously, the script was copying a file named `git-se.txt` to the clipboard, but with this changeset, it now copies a file specified by the variable `AI_PROMPT_FILENAME`. This ensures that the correct file is copied to the clipboard, enhancing the accuracy and usability of the script.

```diff
diff --git a/git-se.py b/git-se.py
index bd25ebd..fecffbb 100755
--- a/git-se.py
+++ b/git-se.py
@@ -679,5 +679,5 @@ ai_file.close()
 
 repo.checkout(origin_ref)
 
-subprocess.Popen(["/usr/bin/env", "bash", "-c", "cat {}/git-se.txt | copyq copy -".format(SE_DIR)])
+subprocess.Popen(["/usr/bin/env", "bash", "-c", "cat {}/{} | copyq copy -".format(SE_DIR, AI_PROMPT_FILENAME)])
 

```

## 4. Introduce a new variable for unwrapped description

Introduce a new variable `pd_com_line_unwrapped` to store the unwrapped version of the existing `pd_com_line` variable in the `git-se.py` file. This change is made within the `main` function at line 501. The new variable is assigned the value of `pd_com_line`, which is stripped of leading and trailing whitespaces.

```diff
diff --git a/git-se.py b/git-se.py
index 80c7c86..fecffbb 100755
--- a/git-se.py
+++ b/git-se.py
@@ -501,6 +501,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             logger.debug("comment: {}".format(com_line))
             pd_com_line = com_line
             pd_com_line = pd_com_line.strip(" \t\n")
+            pd_com_line_unwrapped = pd_com_line
 
             # ask AI to generate some description
             if oai:

```

## 5. Write to AI prompt file changeset unwrapped description

This changeset modifies the `git-se.py` file. It adds a new line to include the unwrapped content of the AI prompt response in the `pd_com_line_unwrapped` variable. Additionally, it updates the writing to the AI file to use the `pd_com_line_unwrapped` instead of `pd_com_line`, and changes the formatting to use a `diff` code block.

```diff
diff --git a/git-se.py b/git-se.py
index 5ad2fa9..fecffbb 100755
--- a/git-se.py
+++ b/git-se.py
@@ -525,6 +525,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     logger.debug("gpt: {}".format(response.choices[0].message.content))
                     wrapped = textwrap.wrap(response.choices[0].message.content, 60, break_long_words=False)
                     pd_com_line += "\n\n"
+                    pd_com_line_unwrapped += "\n\n{}\n".format(response.choices[0].message.content)
                     for lin in wrapped:
                         pd_com_line += lin + "\n"
 
@@ -533,8 +534,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             recreator_file.write("EOF\n")
 
             global ai_chapter
-            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line))
-            ai_file.write("```\n")
+            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line_unwrapped))
+            ai_file.write("```diff\n")
             ai_chapter += 1
             for c in cfg:
                 c.export_patch(ai_file, "")

```
