### PR TITLE
Allow split for added

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -415,7 +415,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             self.selected = not self.selected
 
         def select_ex(self):
-            if self.patch.delta.status != DeltaStatus.MODIFIED:
+            if self.patch.delta.status != DeltaStatus.MODIFIED and self.patch.delta.status != DeltaStatus.ADDED:
                 return
             if self.patch.delta.is_binary:
                 return

--- a/git-se.py
+++ b/git-se.py
@@ -168,10 +168,13 @@ def generate_patch(lines, lines_selected, line_desc, logger):
                     if out_patch[p][0] == '+' or out_patch[p][0] == '-':
                         break
                     uc += 1
-                logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc-2, skipped, skipped_prev))
-                del out_patch[last_patch_header:last_patch_header+uc-3]
-                out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc-3, len_plus - (uc-3), active_patch_header.line2 + uc-3 + skipped_prev, len_minus - (uc-3), active_patch_header.line)
-                patch_line_index -= uc-3
+                if uc > 3:
+                    uc = uc - 3
+                logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc+1, skipped, skipped_prev))
+                if uc > 0:
+                    del out_patch[last_patch_header:last_patch_header+uc]
+                out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - uc, active_patch_header.line2 + uc + skipped_prev, len_minus - uc, active_patch_header.line)
+                patch_line_index -= uc
                 skipped_prev = skipped
                 hunks += 1
 

--- a/git-se.py
+++ b/git-se.py
@@ -229,9 +229,11 @@ def generate_patch(lines, lines_selected, line_desc, logger):
             if out_patch[p][0] == '+' or out_patch[p][0] == '-':
                 break
             uc += 1
+        if uc > 3:
+            uc = uc - 3
         logger.debug("LAST: uc = {}".format(uc))
-        del out_patch[last_patch_header:last_patch_header+uc-3]
-        out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc-3, len_plus - (uc-3), active_patch_header.line2 + uc-3 + skipped_prev, len_minus - (uc-3), active_patch_header.line)
+        del out_patch[last_patch_header:last_patch_header+uc]
+        out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - (uc), active_patch_header.line2 + uc + skipped_prev, len_minus - (uc), active_patch_header.line)
         hunks += 1
 
     # report outcome


### PR DESCRIPTION
## 1. Do not allow uc to be negative

This changeset modifies the logic in the `git-se.py` file to prevent the variable `uc` from being negative. It achieves this by adding conditions to check if `uc` is greater than 3 and greater than 0 before performing operations that could result in a negative value. If `uc` is greater than 3, it subtracts 3 from `uc` to ensure it remains positive. Additionally, it adjusts the range for deleting elements in the `out_patch` list to avoid negative indices. The `logger` messages have also been updated to reflect the correct range of values for `uc` during the operation.

```diff
diff --git a/git-se.py b/git-se.py
index cbe8369..7c338e8 100755
--- a/git-se.py
+++ b/git-se.py
@@ -171,7 +171,10 @@ def generate_patch(lines, lines_selected, line_desc, logger):
-                logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc-2, skipped, skipped_prev))
-                del out_patch[last_patch_header:last_patch_header+uc-3]
-                out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc-3, len_plus - (uc-3), active_patch_header.line2 + uc-3 + skipped_prev, len_minus - (uc-3), active_patch_header.line)
-                patch_line_index -= uc-3
+                if uc > 3:
+                    uc = uc - 3
+                logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc+1, skipped, skipped_prev))
+                if uc > 0:
+                    del out_patch[last_patch_header:last_patch_header+uc]
+                out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - uc, active_patch_header.line2 + uc + skipped_prev, len_minus - uc, active_patch_header.line)
+                patch_line_index -= uc
                 skipped_prev = skipped
                 hunks += 1
 

```

## 2. Do not allow uc to be negative for the last hunk of the patch

The changeset modifies the `git-se.py` file. It ensures that the variable `uc` is not allowed to be negative for the last hunk of the changeset. This is achieved by adding a condition to check if `uc` is greater than 3, and if so, subtracting 3 from it. Additionally, the deletion range in the `out_patch` list is adjusted to prevent `uc` from being negative. The line generating the patch header is also updated to reflect these changes.

```diff
diff --git a/git-se.py b/git-se.py
index cca124e..7c338e8 100755
--- a/git-se.py
+++ b/git-se.py
@@ -232,6 +232,8 @@ def generate_patch(lines, lines_selected, line_desc, logger):
+        if uc > 3:
+            uc = uc - 3
         logger.debug("LAST: uc = {}".format(uc))
-        del out_patch[last_patch_header:last_patch_header+uc-3]
-        out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc-3, len_plus - (uc-3), active_patch_header.line2 + uc-3 + skipped_prev, len_minus - (uc-3), active_patch_header.line)
+        del out_patch[last_patch_header:last_patch_header+uc]
+        out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - (uc), active_patch_header.line2 + uc + skipped_prev, len_minus - (uc), active_patch_header.line)
         hunks += 1
 
     # report outcome

```

## 3. Allow splitting patches also for ADDED files

This changeset modifies the `git-se.py` file to allow splitting changesets for files that are added. Previously, the condition only checked for `DeltaStatus.MODIFIED` status, but now it has been updated to also include `DeltaStatus.ADDED`. This change ensures that when a file is added, it will be considered for splitting changesets.

```diff
diff --git a/git-se.py b/git-se.py
index 735bb8a..7c338e8 100755
--- a/git-se.py
+++ b/git-se.py
@@ -418,4 +418,4 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
-            if self.patch.delta.status != DeltaStatus.MODIFIED:
+            if self.patch.delta.status != DeltaStatus.MODIFIED and self.patch.delta.status != DeltaStatus.ADDED:
                 return
             if self.patch.delta.is_binary:
                 return

```
