### PR TITLE
Lost context fix

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -231,9 +231,11 @@ def generate_patch(lines, lines_selected, line_desc, logger):
                 break
             uc += 1
         if uc > 3:
-            uc = uc - 3
+            del out_patch[last_patch_header:last_patch_header + uc - 3]
+        uc = uc - 3
+        if uc < 0:
+            uc = 0
         logger.debug("LAST: uc = {}".format(uc))
-        del out_patch[last_patch_header:last_patch_header+uc]
         out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - (uc), active_patch_header.line2 + uc + skipped_prev, len_minus - (uc), active_patch_header.line)
         hunks += 1
 

--- a/git-se.py
+++ b/git-se.py
@@ -169,10 +169,11 @@ def generate_patch(lines, lines_selected, line_desc, logger):
                         break
                     uc += 1
                 if uc > 3:
-                    uc = uc - 3
+                    del out_patch[last_patch_header:last_patch_header + uc - 3]
+                uc = uc - 3
+                if uc < 0:
+                    uc = 0
                 logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc+1, skipped, skipped_prev))
-                if uc > 0:
-                    del out_patch[last_patch_header:last_patch_header+uc]
                 out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - uc, active_patch_header.line2 + uc + skipped_prev, len_minus - uc, active_patch_header.line)
                 patch_line_index -= uc
                 skipped_prev = skipped


### PR DESCRIPTION
## 1. Fix context for issues introduced by previous PR

The changeset fixes the context for issues introduced by a previous pull request. It modifies the logic in the `generate_patch` function in the `git-se.py` file. Specifically, it adjusts the handling of the `uc` variable to ensure the correct context is maintained when generating the patch. The changes include deleting a portion of the `out_patch` list based on the value of `uc`, updating the value of `uc` accordingly, and ensuring that `uc` is not negative. Additionally, it refactors the code to correctly set the patch header based on the adjusted `uc` value. The changes aim to address context-related problems caused by the previous pull request.

```diff
diff --git a/git-se.py b/git-se.py
index 7c338e8..f3b665e 100755
--- a/git-se.py
+++ b/git-se.py
@@ -169,10 +169,11 @@ def generate_patch(lines, lines_selected, line_desc, logger):
                         break
                     uc += 1
                 if uc > 3:
-                    uc = uc - 3
+                    del out_patch[last_patch_header:last_patch_header + uc - 3]
+                uc = uc - 3
+                if uc < 0:
+                    uc = 0
                 logger.debug("uc = {}, remove from: {} to {}, skipped: {}, skipped_prev: {}".format(uc,last_patch_header, last_patch_header+uc+1, skipped, skipped_prev))
-                if uc > 0:
-                    del out_patch[last_patch_header:last_patch_header+uc]
                 out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - uc, active_patch_header.line2 + uc + skipped_prev, len_minus - uc, active_patch_header.line)
                 patch_line_index -= uc
                 skipped_prev = skipped

```

## 2. Fix context issue for last hunk of the patch

The changeset fixes a context issue for the last hunk of the patch in the `git-se.py` file. It adjusts the calculation of the variable `uc` to ensure it is not negative and correctly updates the `out_patch` list by deleting the specified range of lines. This modification aims to address the context problem and improve the patch generation process.

```diff
diff --git a/git-se.py b/git-se.py
index 2e9691a..f3b665e 100755
--- a/git-se.py
+++ b/git-se.py
@@ -231,9 +231,11 @@ def generate_patch(lines, lines_selected, line_desc, logger):
                 break
             uc += 1
         if uc > 3:
-            uc = uc - 3
+            del out_patch[last_patch_header:last_patch_header + uc - 3]
+        uc = uc - 3
+        if uc < 0:
+            uc = 0
         logger.debug("LAST: uc = {}".format(uc))
-        del out_patch[last_patch_header:last_patch_header+uc]
         out_patch[last_patch_header] = "@@ -{},{} +{},{} @@ {}".format(active_patch_header.line1 + uc, len_plus - (uc), active_patch_header.line2 + uc + skipped_prev, len_minus - (uc), active_patch_header.line)
         hunks += 1
 

```
