### PR TITLE
Add support for the shorten hunk header

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -107,6 +107,19 @@ def gen_navigation_map(box, lines, logger):
             out_linedesc[lines_index].len2 = int(current_patch_header.groups()[3]);
             out_linedesc[lines_index].line = current_patch_header.groups()[4];
             logger.debug("patch header: {}".format(str(out_linedesc[lines_index])))
+        if not current_patch_header:
+            current_patch_header = re.search(r"@@\s*\-([0-9]+),([0-9]+)\s+\+([0-9]+)\s*@@\s*(.*)", line)
+            if current_patch_header:
+                out_linedesc[lines_index].line_type = LineType.PATCH_HEADER
+                last_patch_header_line = lines_index
+                header_mode = False
+                pallete = (30, curses.A_BOLD)
+                out_linedesc[lines_index].line1 = int(current_patch_header.groups()[0]);
+                out_linedesc[lines_index].len1 = int(current_patch_header.groups()[1]);
+                out_linedesc[lines_index].line2 = int(current_patch_header.groups()[2]);
+                out_linedesc[lines_index].len2 = int(current_patch_header.groups()[2]);
+                out_linedesc[lines_index].line = current_patch_header.groups()[3];
+                logger.debug("patch header (type 2): {}".format(str(out_linedesc[lines_index])))
 
         if header_mode:
             pallete = (24, curses.A_BOLD)


### PR DESCRIPTION
## 1. Add support for the shorten hunk header

The changeset adds support for the shorten hunk header in the `git-se.py` file. It introduces a condition to handle cases where the current patch header is not found. In such situations, it searches for a different pattern to identify the patch header. If this alternative pattern is found, it sets the necessary attributes for the `out_linedesc` object to represent the patch header of type 2. This modification enhances the functionality of the code by allowing it to recognize and process a different format of patch headers.

```diff
diff --git a/git-se.py b/git-se.py
index f3b665e..dd6eb95 100755
--- a/git-se.py
+++ b/git-se.py
@@ -107,6 +107,19 @@ def gen_navigation_map(box, lines, logger):
             out_linedesc[lines_index].len2 = int(current_patch_header.groups()[3]);
             out_linedesc[lines_index].line = current_patch_header.groups()[4];
             logger.debug("patch header: {}".format(str(out_linedesc[lines_index])))
+        if not current_patch_header:
+            current_patch_header = re.search(r"@@\s*\-([0-9]+),([0-9]+)\s+\+([0-9]+)\s*@@\s*(.*)", line)
+            if current_patch_header:
+                out_linedesc[lines_index].line_type = LineType.PATCH_HEADER
+                last_patch_header_line = lines_index
+                header_mode = False
+                pallete = (30, curses.A_BOLD)
+                out_linedesc[lines_index].line1 = int(current_patch_header.groups()[0]);
+                out_linedesc[lines_index].len1 = int(current_patch_header.groups()[1]);
+                out_linedesc[lines_index].line2 = int(current_patch_header.groups()[2]);
+                out_linedesc[lines_index].len2 = int(current_patch_header.groups()[2]);
+                out_linedesc[lines_index].line = current_patch_header.groups()[3];
+                logger.debug("patch header (type 2): {}".format(str(out_linedesc[lines_index])))
 
         if header_mode:
             pallete = (24, curses.A_BOLD)

```
