### PR TITLE
Description final edit

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -576,11 +576,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     if response and len(response.choices)>0:
                         # need to format output line (max of 60 chars)
                         logger.debug("gpt: {}".format(response.choices[0].message.content))
-                        wrapped = textwrap.wrap(response.choices[0].message.content, 60, break_long_words=False)
                         pd_com_line += "\n\n"
-                        pd_com_line_unwrapped += "\n\n{}\n".format(response.choices[0].message.content)
-                        for lin in wrapped:
-                            pd_com_line += lin + "\n"
+                        pd_com_line += response.choices[0].message.content
 
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))

--- a/git-se.py
+++ b/git-se.py
@@ -579,6 +579,16 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         pd_com_line += "\n\n"
                         pd_com_line += response.choices[0].message.content
 
+            if not skip_generative_AI:
+                with open(SE_DIR + "/git-se._stage_desc.txt", "w") as staged:
+                    staged.write("# Please review generated comments by AI. Lines starting with # will be ignored\n")
+                    staged.write("#\n")
+                    for c in cfg:
+                        staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
+                        staged.write("#\n")
+                        c.export_patch(staged, "# ")
+                    staged.write("\n")
+                    staged.write(f"{pd_com_line}\n")
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))
             recreator_file.write("EOF\n")

--- a/git-se.py
+++ b/git-se.py
@@ -591,8 +591,34 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     staged.write(f"{pd_com_line}\n")
 
                 subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])
+
+                com_line = ""
+                with open(SE_DIR + "/git-se._stage_desc.txt", "r") as staged:
+                    while lc := staged.readline():
+                        if lc[0] != "#":
+                            com_line += lc
+
+                pd_com_line = com_line.strip(" \t\n")
+
+
+            pd_com_line_unwrapped = pd_com_line
+            # now split pd_com_line into paragraphs
+            p_num = 0
+            pd_com_wrapped = ""
+            paragraphs = pd_com_line.split('\n')
+            for p_line in paragraphs:
+                p_line_c = p_line.strip(" \t\n")
+                if len(p_line_c) > 0:
+                    if p_num == 0:
+                        pd_com_wrapped += p_line_c + "\n"
+                    else:
+                        pd_com_wrapped += "\n"
+                        pd_com_wrapped += "\n".join(textwrap.wrap(p_line_c, 80, break_long_words=False, break_on_hyphens=False))
+                        pd_com_wrapped += "\n"
+                    p_num += 1
+
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
-            recreator_file.write("{}\n".format(pd_com_line))
+            recreator_file.write("{}\n".format(pd_com_wrapped))
             recreator_file.write("EOF\n")
 
             global ai_chapter

--- a/git-se.py
+++ b/git-se.py
@@ -589,6 +589,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         c.export_patch(staged, "# ")
                     staged.write("\n")
                     staged.write(f"{pd_com_line}\n")
+
+                subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))
             recreator_file.write("EOF\n")

--- a/git-se.py
+++ b/git-se.py
@@ -552,10 +552,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         com_line += lc
                     elif lc.startswith("#[no-ai]"):
                         skip_generative_AI = True
-            logger.debug("comment: {}".format(com_line))
-            pd_com_line = com_line
-            pd_com_line = pd_com_line.strip(" \t\n")
-            pd_com_line_unwrapped = pd_com_line
+            pd_com_line = com_line.strip(" \t\n")
+            logger.debug(f"comment: {pd_com_line}")
 
             # ask AI to generate some description
             if oai and not skip_generative_AI:


### PR DESCRIPTION
## 1. Simplify pd_com_line processing

The changeset simplifies the processing of the `pd_com_line` in the `git-se.py` file. It removes the unnecessary assignment of `com_line` to `pd_com_line` and directly assigns the stripped version of `com_line` to `pd_com_line`. Additionally, it updates the debug log message to reflect this change by logging the stripped `pd_com_line` instead of the original `com_line`.
```diff
diff --git a/git-se.py b/git-se.py
index 456aa48..21efc2d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -552,10 +552,8 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         com_line += lc
                     elif lc.startswith("#[no-ai]"):
                         skip_generative_AI = True
-            logger.debug("comment: {}".format(com_line))
-            pd_com_line = com_line
-            pd_com_line = pd_com_line.strip(" \t\n")
-            pd_com_line_unwrapped = pd_com_line
+            pd_com_line = com_line.strip(" \t\n")
+            logger.debug(f"comment: {pd_com_line}")
 
             # ask AI to generate some description
             if oai and not skip_generative_AI:

```

## 2. After we receive generated description just add it to pd_com_line

The changeset modifies the `git-se.py` file. It removes the text wrapping functionality for a response message, which was limiting the output to 60 characters per line. Instead, it now appends the message content directly to `pd_com_line`. This change simplifies the formatting process and ensures that the full message content is included in the output.
```diff
diff --git a/git-se.py b/git-se.py
index c08d54e..21efc2d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -576,14 +576,11 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     if response and len(response.choices)>0:
                         # need to format output line (max of 60 chars)
                         logger.debug("gpt: {}".format(response.choices[0].message.content))
-                        wrapped = textwrap.wrap(response.choices[0].message.content, 60, break_long_words=False)
                         pd_com_line += "\n\n"
-                        pd_com_line_unwrapped += "\n\n{}\n".format(response.choices[0].message.content)
-                        for lin in wrapped:
-                            pd_com_line += lin + "\n"
+                        pd_com_line += response.choices[0].message.content
 
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))
             recreator_file.write("EOF\n")
 
             global ai_chapter

```

## 3. Write the user description together with generated back to stage file

This changeset modifies the `git-se.py` file. It adds a new condition to check if `skip_generative_AI` is false. If it is false, it opens a file named `git-se._stage_desc.txt` in write mode within the `SE_DIR` directory. It writes a header for the file instructing to review the generated comments by AI and specifies that lines starting with `#` will be ignored. Then, for each item in `cfg`, it writes the marking and the path of the new file to the file, followed by exporting the patch content with a prefix of `#`. After that, it writes the `pd_com_line` content to the file. Additionally, it updates the `recreator_file` by adding the content of `pd_com_line` within a here document.
```diff
diff --git a/git-se.py b/git-se.py
index 0d6647c..21efc2d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -579,8 +579,18 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         pd_com_line += "\n\n"
                         pd_com_line += response.choices[0].message.content
 
+            if not skip_generative_AI:
+                with open(SE_DIR + "/git-se._stage_desc.txt", "w") as staged:
+                    staged.write("# Please review generated comments by AI. Lines starting with # will be ignored\n")
+                    staged.write("#\n")
+                    for c in cfg:
+                        staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
+                        staged.write("#\n")
+                        c.export_patch(staged, "# ")
+                    staged.write("\n")
+                    staged.write(f"{pd_com_line}\n")
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))
             recreator_file.write("EOF\n")
 
             global ai_chapter

```

## 4. Run `nano` for user to edit the final description

The changeset modifies the `git-se.py` file to include a new subprocess call to run the `nano` text editor for the user to edit the final description. This subprocess call opens the `git-se._stage_desc.txt` file using `nano`. This allows the user to make changes to the description before proceeding further in the script.
```diff
diff --git a/git-se.py b/git-se.py
index cda8473..21efc2d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -589,8 +589,10 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                         c.export_patch(staged, "# ")
                     staged.write("\n")
                     staged.write(f"{pd_com_line}\n")
+
+                subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
             recreator_file.write("{}\n".format(pd_com_line))
             recreator_file.write("EOF\n")
 
             global ai_chapter

```

## 5. Format the final description

This changeset loads the final description and makes two variants of descriptions. First is unwrapped and the second one is for commit messages (max of 80 letters wrapped).

This changeset modifies the `git-se.py` file by adding functionality to format the final description. It introduces two variants of descriptions: one unwrapped (`pd_com_line_unwrapped`) and the other for commit messages (`pd_com_wrapped`). The commit message variant is wrapped to a maximum of 80 characters per line. The patch also includes logic to split the description into paragraphs and wrap each paragraph accordingly. The final formatted description is then written to `git-se._stage_desc_clean.txt`.
```diff
diff --git a/git-se.py b/git-se.py
index c75b711..21efc2d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -591,8 +591,34 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                     staged.write(f"{pd_com_line}\n")
 
                 subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])
+
+                com_line = ""
+                with open(SE_DIR + "/git-se._stage_desc.txt", "r") as staged:
+                    while lc := staged.readline():
+                        if lc[0] != "#":
+                            com_line += lc
+
+                pd_com_line = com_line.strip(" \t\n")
+
+
+            pd_com_line_unwrapped = pd_com_line
+            # now split pd_com_line into paragraphs
+            p_num = 0
+            pd_com_wrapped = ""
+            paragraphs = pd_com_line.split('\n')
+            for p_line in paragraphs:
+                p_line_c = p_line.strip(" \t\n")
+                if len(p_line_c) > 0:
+                    if p_num == 0:
+                        pd_com_wrapped += p_line_c + "\n"
+                    else:
+                        pd_com_wrapped += "\n"
+                        pd_com_wrapped += "\n".join(textwrap.wrap(p_line_c, 80, break_long_words=False, break_on_hyphens=False))
+                        pd_com_wrapped += "\n"
+                    p_num += 1
+
             recreator_file.write("cat << 'EOF' > {}/git-se._stage_desc_clean.txt\n".format(SE_DIR))
-            recreator_file.write("{}\n".format(pd_com_line))
+            recreator_file.write("{}\n".format(pd_com_wrapped))
             recreator_file.write("EOF\n")
 
             global ai_chapter

```
