### PR TITLE
Now to quit the git-se you need to press the key 3 times

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -495,6 +495,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 idx.add(self.patch.delta.new_file.path)
                 recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.new_file.path))
 
+    quit_attempt = 0
     while True:
         # draw menu
         start_oft = 4
@@ -516,7 +517,9 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
         key = stdscr.getch()
 
         if key == curses.KEY_F10 or key == 113:
-            break
+            quit_attempt += 1
+            if quit_attempt > 2:
+                break
 
         if key == curses.KEY_F2:
             if not ready_to_stage(cfg):


### PR DESCRIPTION
## 1. Now to quit the git-se you need to press the key 3 times

The changeset modifies the `git-se.py` file to require pressing the quit key three times in order to exit the `git-se` program. This change ensures that users do not accidentally quit the program and adds a confirmation step to the quitting process.
```diff
diff --git a/git-se.py b/git-se.py
index 21efc2d..b0d883d 100755
--- a/git-se.py
+++ b/git-se.py
@@ -495,6 +495,7 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 idx.add(self.patch.delta.new_file.path)
                 recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.new_file.path))
 
+    quit_attempt = 0
     while True:
         # draw menu
         start_oft = 4
@@ -516,7 +517,9 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
         key = stdscr.getch()
 
         if key == curses.KEY_F10 or key == 113:
-            break
+            quit_attempt += 1
+            if quit_attempt > 2:
+                break
 
         if key == curses.KEY_F2:
             if not ready_to_stage(cfg):

```
