### PR TITLE
Squeze reformat

### DIFF
--- a/git-se.py
+++ b/git-se.py
@@ -543,9 +543,10 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 staged.write("# Use #[no-ai] tag to skip generative AI comments\n")
                 staged.write("#\n")
                 for c in cfg:
-                    staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
-                    staged.write("#\n")
-                    c.export_patch(staged, "# ")
+                    is_partial, pp = c.squeze("# ")
+                    pp = pp.strip(" \t\n")
+                    if len(pp) > 0:
+                        staged.write(f"{pp}\n")
                 staged.write("\n")
 
             subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])

--- a/git-se.py
+++ b/git-se.py
@@ -647,14 +647,29 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             recreator_file.write("EOF\n")
 
             global ai_chapter
-            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line_unwrapped))
-            ai_file.write("```diff\n")
+            ai_file.write("\n## {}. {}\n\n".format(ai_chapter, pd_com_line_unwrapped))
+
             ai_chapter += 1
             for c in cfg:
-                c.export_patch(ai_file, "")
-            ai_file.write("\n")
+                is_partial, pp = c.squeze()
+                pp = pp.strip(" \t\n")
+                if len(pp)>0 and is_partial:
+                    ai_file.write("```diff\n")
+                    ai_file.write(f"{pp}\n")
+                    ai_file.write("```\n")
+            all_non_partials = ""
+            for c in cfg:
+                is_partial, pp = c.squeze()
+                pp = pp.strip(" \t\n")
+                if len(pp)>0 and not is_partial:
+                    all_non_partials += pp + "\n"
 
-            ai_file.write("```\n")
+            if len(all_non_partials)>0:
+                ai_file.write("\n### File changes\n```\n")
+                ai_file.write(f"{all_non_partials}\n")
+                ai_file.write("```\n")
+
+            ai_file.write("\n")
 
             index = repo.index
             author = pygit2.Signature('Git Se', 'gitse@gitse.se')

--- a/git-se.py
+++ b/git-se.py
@@ -605,10 +605,13 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 with open(SE_DIR + "/git-se._stage_desc.txt", "w") as staged:
                     staged.write("# Please review generated comments by AI. Lines starting with # will be ignored\n")
                     staged.write("#\n")
+
                     for c in cfg:
-                        staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
-                        staged.write("#\n")
-                        c.export_patch(staged, "# ")
+                        is_partial, pp = c.squeze("# ")
+                        pp = pp.strip(" \t\n")
+                        if len(pp) > 0:
+                            staged.write(f"{pp}\n")
+
                     staged.write("\n")
                     staged.write(f"{pd_com_line}\n")
 

--- a/git-se.py
+++ b/git-se.py
@@ -495,9 +495,16 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
         def add_to_index(self, idx):
             if self.partially_selected or self.selected:
                 if self.patch.delta.new_file.path != self.patch.delta.old_file.path:
-                    idx.add(self.patch.delta.old_file.path)
+                    if self.patch.delta.status == DeltaStatus.DELETED:
+                        idx.remove(self.patch.delta.old_file.path)
+                    else:
+                        idx.add(self.patch.delta.old_file.path)
                     recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.old_file.path))
-                idx.add(self.patch.delta.new_file.path)
+                self.logger.debug(f"delta status = {self.patch.delta.status} for {self.patch.delta.new_file.path}")
+                if self.patch.delta.status == DeltaStatus.DELETED:
+                    idx.remove(self.patch.delta.new_file.path)
+                else:
+                    idx.add(self.patch.delta.new_file.path)
                 recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.new_file.path))
 
     quit_attempt = 0

--- a/git-se.py
+++ b/git-se.py
@@ -576,9 +576,15 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
 
                 patches = ""
                 for c in cfg:
-                    pp = c.squeze()
+                    is_partial, pp = c.squeze()
+                    pp = pp.strip(" \t\n")
                     if len(pp) > 0:
-                        patches += "```\n{}\n```".format(json.dumps(pp));
+                        if is_partial:
+                            patches += "```diff\n{}\n```".format(json.dumps(pp));
+                        else:
+                            patches += "```{}```\n".format(json.dumps(pp));
+
+                logger.debug(f"sending patches: {patches}")
 
                 if len(patches) > 0:
                     response = oai.chat.completions.create(


### PR DESCRIPTION
## 1. Squeze function modifications

Now it can accept prefix parameter. For fully selected files it generates brief information and for partially selected it generates the patch

The changeset modifies the `squeze` function in the `git-se.py` file to accept a `prefix` parameter. If the file is binary and partially selected, it will return a tuple with `False` and an empty string. The function now checks if the file is partially selected and adds the `prefix` to each line in the partial patch. If the file is fully selected, it adds the `prefix` to indicate whether it's an addition or deletion. The function now returns a tuple with a boolean indicating if it's partially selected and the generated output. Debug messages have been added to log the status of the file and the output.

```diff
diff --git a/git-se.py b/git-se.py
index b0d883d..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -439,21 +439,26 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             self.partial_patch = partially_select(stdscr, self, self.logger)
             self.partially_selected = self.partial_patch != None
 
-        def squeze(self):
+        def squeze(self, prefix=""):
             # do not do anything if it's binary
-            if self.patch.delta.is_binary:
-                return ""
-
+            if self.patch.delta.is_binary and self.partially_selected:
+                return (False, "")
+            is_partial = True
             out = ""
+
             if self.partially_selected:
+                self.logger.debug(f"{self.patch.delta.new_file.path} is partially selected and delta status = {self.patch.delta.status} for {self.patch.delta.new_file.path}")
                 for line in self.partial_patch:
-                    out += line + "\n"
+                    out += prefix + line + "\n"
             elif self.selected:
-                text_patch = self.patch.data.decode('utf-8')
-                lines = text_patch.splitlines()
-                for line in lines:
-                    out += line + "\n"
-            return out
+                self.logger.debug(f"{self.patch.delta.new_file.path} is fully selected and delta status = {self.patch.delta.status} for {self.patch.delta.new_file.path}")
+                is_partial = False
+                if self.patch.delta.status == DeltaStatus.DELETED:
+                    out += prefix + " [-] " + self.patch.delta.new_file.path
+                else:
+                    out += prefix + " [+] " + self.patch.delta.new_file.path
+            self.logger.debug(f"output = [{out}]")
+            return (is_partial, out)
 
         def export_patch(self, fil, prefix):
             # do not do anything if it's binary
```


## 2. Function add_to_index is now respecting the delta status

The changeset modifies the `add_to_index` function in the `git-se.py` file to ensure it respects the delta status. Previously, the function would unconditionally add the old and new file paths to the index. With this changeset, the function now checks if the delta status is `DELETED` before deciding to remove or add the file path to the index accordingly. Additionally, debug logging has been added to track the delta status for each file path being processed by the function.

```diff
diff --git a/git-se.py b/git-se.py
index 124d94f..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -495,9 +495,16 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
         def add_to_index(self, idx):
             if self.partially_selected or self.selected:
                 if self.patch.delta.new_file.path != self.patch.delta.old_file.path:
-                    idx.add(self.patch.delta.old_file.path)
+                    if self.patch.delta.status == DeltaStatus.DELETED:
+                        idx.remove(self.patch.delta.old_file.path)
+                    else:
+                        idx.add(self.patch.delta.old_file.path)
                     recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.old_file.path))
-                idx.add(self.patch.delta.new_file.path)
+                self.logger.debug(f"delta status = {self.patch.delta.status} for {self.patch.delta.new_file.path}")
+                if self.patch.delta.status == DeltaStatus.DELETED:
+                    idx.remove(self.patch.delta.new_file.path)
+                else:
+                    idx.add(self.patch.delta.new_file.path)
                 recreator_file.write("git add {}/{}\n".format(WORK_DIR, self.patch.delta.new_file.path))
 
     quit_attempt = 0
```


## 3. Replace `export_patch` with `squeze` functionality

Replace `export_patch` with `squeze` functionality in the `git-se.py` file. The `squeze` function is called on each element in `cfg`, and if there is a non-empty result, it is written to the `staged` file. Additionally, the result is stripped of leading and trailing whitespaces before being written.

```diff
diff --git a/git-se.py b/git-se.py
index ef346c9..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -543,9 +543,10 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 staged.write("# Use #[no-ai] tag to skip generative AI comments\n")
                 staged.write("#\n")
                 for c in cfg:
-                    staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
-                    staged.write("#\n")
-                    c.export_patch(staged, "# ")
+                    is_partial, pp = c.squeze("# ")
+                    pp = pp.strip(" \t\n")
+                    if len(pp) > 0:
+                        staged.write(f"{pp}\n")
                 staged.write("\n")
 
             subprocess.run(["nano", SE_DIR + "/git-se._stage_desc.txt"])
```


## 4. Reformat using `squeze` before sending it to openAI

The changeset modifies the `git-se.py` file to reformat the patches before sending them to OpenAI. It introduces a new method `squeze()` which now returns a tuple with a boolean indicating if the patch is partial and the reformatted patch. The reformatted patch is then stripped of leading and trailing whitespaces. Depending on whether the patch is partial or not, it is now enclosed in either a `diff` code block or a regular code block. Additionally, the changeset adds a debug log statement to output the patches being sent before sending them to OpenAI.

```diff
diff --git a/git-se.py b/git-se.py
index de1fcc5..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -576,9 +576,15 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
 
                 patches = ""
                 for c in cfg:
-                    pp = c.squeze()
+                    is_partial, pp = c.squeze()
+                    pp = pp.strip(" \t\n")
                     if len(pp) > 0:
-                        patches += "```\n{}\n```".format(json.dumps(pp));
+                        if is_partial:
+                            patches += "```diff\n{}\n```".format(json.dumps(pp));
+                        else:
+                            patches += "```{}```\n".format(json.dumps(pp));
+
+                logger.debug(f"sending patches: {patches}")
 
                 if len(patches) > 0:
                     response = oai.chat.completions.create(
```


## 5. Reformat using `squeze` after openAI

The changeset reformat the code in `git-se.py` file. It adds a new functionality after the line where comments are written. It introduces a loop that iterates over `cfg` elements. For each element, it calls the `squeze` method and writes the result to the file. The result is then stripped of leading and trailing whitespaces and checked if it's not empty before writing it to the file. This changeset modifies the way patches are exported to the file by using the `squeze` method.

```diff
diff --git a/git-se.py b/git-se.py
index 3c553f6..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -605,10 +605,13 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
                 with open(SE_DIR + "/git-se._stage_desc.txt", "w") as staged:
                     staged.write("# Please review generated comments by AI. Lines starting with # will be ignored\n")
                     staged.write("#\n")
+
                     for c in cfg:
-                        staged.write("# [{}] {}\n".format(c.marking(), c.patch.delta.new_file.path))
-                        staged.write("#\n")
-                        c.export_patch(staged, "# ")
+                        is_partial, pp = c.squeze("# ")
+                        pp = pp.strip(" \t\n")
+                        if len(pp) > 0:
+                            staged.write(f"{pp}\n")
+
                     staged.write("\n")
                     staged.write(f"{pd_com_line}\n")
```


## 6. Reformat using `squeze` when dumping report to ai-prompt

The changeset modifies the `git-se.py` file to reformat the way reports are dumped to `ai-prompt`. It introduces the use of the `squeze` method when iterating through configurations. For configurations that are partial, it now includes the diff output within triple backticks. Additionally, it collects all non-partial configurations and appends their diff outputs together. If there are any non-partial configurations collected, it adds a section titled "File changes" followed by the aggregated diff outputs within triple backticks.

```diff
diff --git a/git-se.py b/git-se.py
index ce1b542..53413a5 100755
--- a/git-se.py
+++ b/git-se.py
@@ -647,14 +647,29 @@ def main(stdscr, sd, repo, first_commit, git_se_head, local_head):
             recreator_file.write("EOF\n")
 
             global ai_chapter
-            ai_file.write("\n## {}. {}\n".format(ai_chapter, pd_com_line_unwrapped))
-            ai_file.write("```diff\n")
+            ai_file.write("\n## {}. {}\n\n".format(ai_chapter, pd_com_line_unwrapped))
+
             ai_chapter += 1
             for c in cfg:
-                c.export_patch(ai_file, "")
-            ai_file.write("\n")
+                is_partial, pp = c.squeze()
+                pp = pp.strip(" \t\n")
+                if len(pp)>0 and is_partial:
+                    ai_file.write("```diff\n")
+                    ai_file.write(f"{pp}\n")
+                    ai_file.write("```\n")
+            all_non_partials = ""
+            for c in cfg:
+                is_partial, pp = c.squeze()
+                pp = pp.strip(" \t\n")
+                if len(pp)>0 and not is_partial:
+                    all_non_partials += pp + "\n"
 
-            ai_file.write("```\n")
+            if len(all_non_partials)>0:
+                ai_file.write("\n### File changes\n```\n")
+                ai_file.write(f"{all_non_partials}\n")
+                ai_file.write("```\n")
+
+            ai_file.write("\n")
 
             index = repo.index
             author = pygit2.Signature('Git Se', 'gitse@gitse.se')
```

